### PR TITLE
Add support for large swaps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # HashStrat - Pools and Strategies
 
-This repo contains the suite of Solidity smart contracts for HashStrat Pools and Strategies.
+This repo contains the suite of Solidity smart contracts for the HashStrat Pools and Strategies.
 
-- HashStrat Pools hold a risk asset (e.g WETH or WBTC) and a stable asset (e.g USDC).
-- Each Pool is configured with a Strategy that is able to trade between the risk asset and the stable asset held in the Pool.
-- Users can deposit USDC into a Pool. The Pool's strategy determine the inital portfolio allocation (e.g. the split between risk and stable asset) and will automatically manage it over time, with the goal to capture volatility in the risk asset and manage risk.
+- HashStrat pools hold a risk asset (e.g WETH or WBTC) and a stable asset (e.g USDC).
+- Each pool is configured with a Strategy that is able to trade between the risk asset and the stable asset held in the pool.
+- Users can deposit USDC into a pool. The pool's strategy will determine the inital portfolio allocation (e.g. the split between risk and stable asset) and will automatically manage the allocation over time, with the goal to capture volatility in the risk asset and manage risk.
 
 Strategies use [Chainlink data feeds](https://docs.chain.link/docs/matic-addresses/) to assist their trading logic.  
 [Chainlink Automation](https://docs.chain.link/chainlink-automation/introduction/) is used automate the strategy execution.
 
-So far there are 3 strategies:
+So far there are 3 strategies. More will be added in the future:
 1. MeanReversionV1: DCA in and out the risk asset when its price deviates significantly from a long term moving average.
-2. RebalancingV1: Ensures to rebalance the assets in the Pool when their value moves above or below predetermined levels of the overall value of the Pool.
+2. RebalancingV1: Ensures to rebalance the assets in the pool when their value moves above or below predetermined levels of the overall value of the pool.
 3. TrendFollowV1: Allocates to the risk asset when its price moves above a short term moving average and sells into the stable asset when it moves below.
  
 
@@ -88,17 +88,17 @@ npm run verify:matic
 ## HowTo use the Pool Contract (Polygon)
 
 1. Approve Pool contract to spend USDC 
-- call `approve` function on [USDC contract](https://polygonscan.com/token/0x2791bca1f2de4661ed88a30c99a7a9449aa84174#writeProxyContract) providing the Pool address.
+- call `approve` function on [USDC contract](https://polygonscan.com/token/0x2791bca1f2de4661ed88a30c99a7a9449aa84174#writeProxyContract) providing the pool address.
 
 2. Deposit funds:
-- call `deposit` function on Pool contract and pass the amount of USDC tokens to deposit. 
-- The account receives an amount LP tokens proportional to the percentage of the pool value deposited into the Pool.
+- call `deposit` function on pool contract and pass the amount of USDC tokens to deposit. 
+- The account receives an amount LP tokens proportional to the percentage of the pool value deposited into the pool.
 
 3. Withdraw funds:
-- call `withdrawLP` function on Pool contract providing the amount of LP tokens to withdraw.
-- call `withdrawAll` function on Pool contract to withdraw all LP tokens.
+- call `withdrawLP` function on pool contract providing the amount of LP tokens to withdraw.
+- call `withdrawAll` function on pool contract to withdraw all LP tokens.
 - Burns the LP tokens withrawn and sends the correspective value in USDC to the account.
 
 4. Execute strategy:
-Call the `performUpkeep` function on the Pool contract. This will trigger the execution of the Pool's strategy provided the `checkUpkeep` function returns true.
+Call the `performUpkeep` function on the pool contract. This will trigger the execution of the pool's strategy provided the `checkUpkeep` function returns true.
 Alternatively wait for [Chainlink Automation](https://automation.chain.link/polygon) to trigger a strategy execution.

--- a/contracts/__mocks__/UniswapV2RouterMock.sol
+++ b/contracts/__mocks__/UniswapV2RouterMock.sol
@@ -4,17 +4,18 @@ pragma solidity ^0.8.14;
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
-
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "../swaps/IUniswapV2Router.sol";
-
+import "../TokenMaths.sol";
 
 /**
     Mock implementation of swap functionality and price feed via the interfaces:
     - UniswapV2Router to swap depositTokens into investTokens
     - AggregatorV3Interface to provide price for the  investTokens/depositTokens pair
  */
-contract UniswapV2RouterMock is IUniswapV2Router {
+contract UniswapV2RouterMock is ReentrancyGuard, IUniswapV2Router {
 
+    using TokenMaths for uint;
 
     IERC20Metadata internal depositToken;
     IERC20Metadata internal investToken;
@@ -59,44 +60,23 @@ contract UniswapV2RouterMock is IUniswapV2Router {
         ) = investTokenFeed.latestRoundData();
     }
 
-    function getFeedDecimals() public view returns (uint8 decimals) {
-        decimals = investTokenFeed.decimals();
-    }
-
-
-
 
     function getAmountsOut(uint amountIn, address[] calldata path) external override view returns (uint[] memory amounts) {
         
         uint price = uint(getPrice());
-        uint pricePrecision = 10 ** getFeedDecimals();
-
         uint[] memory amountOutMins = new uint[](path.length);
-        uint amountOut;
+        uint amountOut = 0;
 
         if (path[0] == address(depositToken)) {
-
-            uint tokenInDecimals = uint(depositToken.decimals());
-            uint tokenOutDecimals = uint(investToken.decimals());
-
-            // swap USD => ETH
-              uint amountInAdjusted = (tokenOutDecimals >= tokenInDecimals) ?
-                 amountIn * (10 ** (tokenOutDecimals - tokenInDecimals)) :
-                 amountIn / (10 ** (tokenInDecimals - tokenOutDecimals));
-
-            amountOut = amountInAdjusted * pricePrecision / price * (10000 - slippage) / 10000;
+            amountOut = amountIn.div(price,
+                depositToken.decimals(), investTokenFeed.decimals(), investToken.decimals()
+            ) * (10000 - uint(slippage)) / 10000;
 
         } else if (path[0] == address(investToken)) {
             // swap ETH => USD
-
-            uint tokenInDecimals = uint(investToken.decimals());
-            uint tokenOutDecimals = uint(depositToken.decimals());
-
-            uint amountInAdjusted = (tokenOutDecimals >= tokenInDecimals) ?
-               amountIn * (10 ** (tokenOutDecimals - tokenInDecimals)) :
-               amountIn / (10 ** (tokenInDecimals - tokenOutDecimals));
-
-            amountOut = amountInAdjusted * price / pricePrecision * (10000 - slippage) / 10000;
+            amountOut = amountIn.mul(price,    // * price / pricePrecision * (10000 - uint(slippage)) / 10000;
+                investToken.decimals(), depositTokenFeed.decimals(),  depositToken.decimals()
+            ) * (10000 - uint(slippage)) / 10000;
         }
 
         amountOutMins[path.length-1] = amountOut;
@@ -109,44 +89,33 @@ contract UniswapV2RouterMock is IUniswapV2Router {
         address[] calldata path,
         address to,
         uint /*deadline*/
-    )  external override returns (uint[] memory amounts) {
+    )  external nonReentrant override returns (uint[] memory amounts) {
 
         uint price = uint(getPrice());
-        uint pricePrecision = 10 ** getFeedDecimals();
-
-        uint depositTokenDecimals = uint(depositToken.decimals());
-        uint investTokensDecimals = uint(investToken.decimals());
-        
-        uint amountOut;
+        uint amountOut = 0;
 
         if (path[0] == address(depositToken)) {
             // swap USD => ETH
+            assert(depositToken.transferFrom(msg.sender, address(this), amountIn));
 
-            depositToken.transferFrom(msg.sender, address(this), amountIn);
-            // account for difference in decimal places
-            uint amountInAdjusted = (investTokensDecimals >= depositTokenDecimals) ?
-                    amountIn * (10 ** (investTokensDecimals - depositTokenDecimals)) :
-                    amountIn / (10 ** (depositTokenDecimals - investTokensDecimals));
-    
-            amountOut = amountInAdjusted * pricePrecision / price * (10000 - uint(slippage)) / 10000;
+            amountOut = amountIn.div(price,
+                depositToken.decimals(), investTokenFeed.decimals(), investToken.decimals()
+            ) * (10000 - uint(slippage)) / 10000;
+
             require(investToken.balanceOf(address(this)) >= amountOut, "Mock UniswapV2: Not enough risk assets");
-            investToken.transfer(to, amountOut);
-
+            assert(investToken.transfer(to, amountOut));
             emit Swapped("BOUGHT", amountIn, amountOut, price, slippage);
 
         } else if (path[0] == address(investToken)) {
             // swap ETH => USD
-            investToken.transferFrom(msg.sender, address(this), amountIn);
-            // account for difference in decimal places
-            uint amountInAdjusted = (investTokensDecimals >= depositTokenDecimals) ?
-                    amountIn / (10 ** (investTokensDecimals - depositTokenDecimals)) :
-                    amountIn * (10 ** (depositTokenDecimals - investTokensDecimals));
+            assert(investToken.transferFrom(msg.sender, address(this), amountIn));
 
-            amountOut = amountInAdjusted * price / pricePrecision * (10000 - uint(slippage)) / 10000;
-            
+            amountOut = amountIn.mul(price,    // * price / pricePrecision * (10000 - uint(slippage)) / 10000;
+                investToken.decimals(), depositTokenFeed.decimals(),  depositToken.decimals()
+            ) * (10000 - uint(slippage)) / 10000;
+
             require(depositToken.balanceOf(address(this)) >= amountOut, "Mock UniswapV2: Not enough stable asset");
-            depositToken.transfer(to, amountOut);
-
+            assert(depositToken.transfer(to, amountOut));
             emit Swapped("SOLD", amountIn, amountOut, price, slippage);
         }
 

--- a/contracts/__mocks__/UniswapV2RouterMock.sol
+++ b/contracts/__mocks__/UniswapV2RouterMock.sol
@@ -7,8 +7,6 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 
 import "../swaps/IUniswapV2Router.sol";
 
-import "hardhat/console.sol";
-
 
 /**
     Mock implementation of swap functionality and price feed via the interfaces:

--- a/contracts/strategies/MeanReversionV1.sol
+++ b/contracts/strategies/MeanReversionV1.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.14;
 
-import "hardhat/console.sol";
-
-
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
@@ -279,8 +276,6 @@ contract MeanReversionV1 is IStrategy, Ownable {
         uint daysSinceLastUpdate =  (block.timestamp - lastEvalTimestamp) / 86400; 
         if (daysSinceLastUpdate == 0) return movingAverage;
 
-        console.log(">>> daysSinceLastUpdate: ", daysSinceLastUpdate);
-
         if (daysSinceLastUpdate < movingAveragePeriod) {
             // update the moving average, using movingAverage price for 'movingAveragePeriod' - 'daysSinceLasUpdate' days 
             // and the current price for the last 'daysSinceLasUpdate' days
@@ -288,13 +283,9 @@ contract MeanReversionV1 is IStrategy, Ownable {
             uint newPriceWeight = daysSinceLastUpdate * uint(price);
             updatedMA = (oldPricesWeight + newPriceWeight ) / movingAveragePeriod;
 
-            console.log(">>> updatedMovingAverage!!: ", oldPricesWeight, newPriceWeight);
-
         } else {
             updatedMA = uint(price);
         }
-
-        console.log(">>> updatedMovingAverage: ", updatedMA);
     }
 
 

--- a/contracts/strategies/RebalancingStrategyV1.sol
+++ b/contracts/strategies/RebalancingStrategyV1.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.14;
 
-import "hardhat/console.sol";
-
-
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";

--- a/contracts/strategies/TrendFollowV1.sol
+++ b/contracts/strategies/TrendFollowV1.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.14;
 
-
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
@@ -85,7 +84,6 @@ contract TrendFollowV1 is IStrategy, Ownable {
      * @return true when strategy needs to be executed because upkeepInterval has elapsed
      */
     function shouldPerformUpkeep() external view returns (bool) {
-
         return (block.timestamp >= lastEvalTimestamp) && (block.timestamp - lastEvalTimestamp >= upkeepInterval);
     }
 

--- a/contracts/swaps/SwapsRouter.sol
+++ b/contracts/swaps/SwapsRouter.sol
@@ -83,6 +83,7 @@ contract SwapsRouter is ISwapsRouter, ReentrancyGuard, Ownable {
                 });
 
             ISwapRouter_Uniswap router = ISwapRouter_Uniswap(routerInfo.routerAddress);
+
             amountOut = router.exactInputSingle(params);
 
         } else if (routerInfo.routerVersion == RouterVersion.V3 && routerInfo.routerType == RouterType.QuickSwap ) {

--- a/contracts/swaps/SwapsRouter.sol
+++ b/contracts/swaps/SwapsRouter.sol
@@ -66,8 +66,9 @@ contract SwapsRouter is ISwapsRouter, ReentrancyGuard, Ownable {
         // transfer the tokens to this contract and aprove spend from the AMM
         RouterInfo memory routerInfo = activeRouter();
 
-        IERC20(tokenIn).transferFrom(msg.sender, address(this), amountIn);
-        IERC20(tokenIn).approve(address(routerInfo.routerAddress), amountIn);
+        bool transferred = IERC20(tokenIn).transferFrom(msg.sender, address(this), amountIn);
+        bool approved = IERC20(tokenIn).approve(address(routerInfo.routerAddress), amountIn);
+        assert (transferred && approved);
 
         if (routerInfo.routerVersion == RouterVersion.V3 && routerInfo.routerType == RouterType.Uniswap ) {
             ISwapRouter_Uniswap.ExactInputSingleParams memory params = ISwapRouter_Uniswap

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -24,8 +24,17 @@ const config : HardhatUserConfig = {
   },
 
   paths: {
-    sources: "./contracts",
-    artifacts: "./artifacts"
+    sources: './contracts',
+    tests: './test',
+    cache: './cache',
+    artifacts: './build/artifacts',
+  },
+
+  abiExporter: {
+    path: './build/abi',
+    clear: true,
+    flat: true,
+    spacing: 2,
   },
 
   gasReporter: {
@@ -52,20 +61,6 @@ const config : HardhatUserConfig = {
       accounts: { mnemonic: MNEMONIC  },
       gasPrice:  120000000000,  // 120 Gwei
     },
-  },
-
-  paths: {
-    sources: './contracts',
-    tests: './test',
-    cache: './cache',
-    artifacts: './build/artifacts',
-  },
-
-  abiExporter: {
-    path: './build/abi',
-    clear: true,
-    flat: true,
-    spacing: 2,
   },
 
   etherscan: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -27,7 +27,7 @@ const config : HardhatUserConfig = {
     sources: './contracts',
     tests: './test',
     cache: './cache',
-    artifacts: './build/artifacts',
+    artifacts: './artifacts',
   },
 
   abiExporter: {
@@ -43,6 +43,7 @@ const config : HardhatUserConfig = {
     noColors: true,
     showTimeSpent: true,
     currency: 'USD',
+    gasPrice: 200
   },
 
   networks: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10445,7 +10445,6 @@
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
@@ -11017,8 +11016,7 @@
       "version": "2.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/node-fetch": {
       "version": "2.1.2",
@@ -11033,7 +11031,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "npx hardhat test",
     "deploy:polygon": "npx hardhat run --network polygon scripts/deploy-polygon.ts",
     "verify:polygon": "npx hardhat verify --network polygon <POOL_ADDR> <PARAMS>",
-    "run-script": "npx hardhat run --network polygon scripts/get-tx-count.ts"
+    "run-get-tx-count": "npx hardhat run --network polygon scripts/get-tx-count.ts",
+    "test-pool-deposits": "npx hardhat run --network hardhat scripts/pool-deposits.ts"
   },
   "keywords": [
     "solidity",

--- a/test/gas_pool_deposits.ts
+++ b/test/gas_pool_deposits.ts
@@ -1,0 +1,137 @@
+
+
+
+import { Contract, BigNumber } from "ethers"
+import { ethers } from "hardhat";
+
+import { fromBtc, fromUsdc, waitSeconds, transferFunds } from "./helpers";
+
+import addresses from "../conf/addresses.json";
+import enums from "../conf/enums.json";
+
+import erc20_abi from "../scripts/abis/erc20.json";
+import pricefeed_aggregator_abi from "./abi/price_feed_aggreagator.json"
+import { expect } from "chai";
+
+const usdc_decimals = 6
+
+
+async function deployPoolContract() {
+
+	// 1. Deploy Pool LP token
+	const PoolLPToken = await ethers.getContractFactory("PoolLPToken")
+	const poolLPToken = await PoolLPToken.deploy("Pool LP Token", "PoolLP", 6)
+	await poolLPToken.deployed()
+
+	// 2. Depoly Strategy
+	const RebalancingStrategyV1 = await ethers.getContractFactory("RebalancingStrategyV1")
+
+	const strategy = await RebalancingStrategyV1.deploy(
+		'0x0000000000000000000000000000000000000000',// pool address not known yet
+		addresses.polygon.usdc_usd_aggregator,
+		addresses.polygon.wbtc_usd_aggregator,
+		addresses.polygon.usdc, 
+		addresses.polygon.wbtc, 
+		60,   // target portfolio 60% WBTC / 40% USDC
+		10,   // 10% seems a good rebalancing band that requires price to double or halve to rebalance
+	); 
+	await strategy.deployed()
+
+
+	// 3. Deploy Router
+	const SwapsRouter = await ethers.getContractFactory("SwapsRouter")
+	const swapRouter = await SwapsRouter.deploy(
+		addresses.polygon.uniswap_v3_quoter,
+		addresses.polygon.quickswap_v3_quoter
+	)
+	await swapRouter.deployed(); 
+
+	// 4. Deploy Pool
+	const poolFees = 100        // 1% fee
+	const uniswapV3Fee = 3000
+	const swapMaxValue = 10_000 * 10 ** 6  // 10k per swap
+
+	const PoolV4 = await ethers.getContractFactory("PoolV4")
+	const pool = await PoolV4.deploy(
+		swapRouter.address,
+		addresses.polygon.usdc_usd_aggregator,
+		addresses.polygon.wbtc_usd_aggregator,
+		addresses.polygon.usdc,
+		addresses.polygon.wbtc,
+		poolLPToken.address,
+		strategy.address,
+		poolFees,
+		uniswapV3Fee,
+		swapMaxValue
+	)
+	await pool.deployed()
+
+	// Configure LP token
+	await poolLPToken.addMinter(pool.address)
+
+	// Configure strategy
+	await strategy.setPool(pool.address)
+	await strategy.transferOwnership(pool.address)
+
+	// Configure Router
+	await swapRouter.addRouter( addresses.polygon.uniswap_v3_router, enums.RouterVersion.V3, enums.RouterType.Uniswap )
+	await swapRouter.addRouter( addresses.polygon.quickswap_v3_router, enums.RouterVersion.V3, enums.RouterType.QuickSwap )
+	await swapRouter.addRouter( addresses.polygon.quickswap_v2_router, enums.RouterVersion.V2, enums.RouterType.QuickSwap )
+	await swapRouter.setActiveRouter(0)
+
+	const usdc = new Contract(addresses.polygon.usdc, erc20_abi, ethers.provider)
+	const wbtc = new Contract(addresses.polygon.wbtc, erc20_abi, ethers.provider)
+
+	const wbtcFeed = new Contract(addresses.polygon.wbtc_usd_aggregator, pricefeed_aggregator_abi, ethers.provider)
+ 
+	return { poolLPToken, swapRouter, strategy, pool, usdc, wbtc, wbtcFeed };
+}
+
+
+describe("Deposit processing gas", function () {
+
+	it.skip("Deposits", async function () {
+
+		const { pool, usdc, wbtc, wbtcFeed } = await deployPoolContract()
+
+		const [ signer, addr1 ] = await ethers.getSigners();
+		await transferFunds(1_000_000 * 10 ** usdc_decimals, addr1.address)
+	
+		const balance = await usdc.balanceOf(addr1.address)
+		console.log("addr1 balance: ", fromUsdc(balance))
+
+		const iterations = 10
+		const deposit = balance.div(iterations)
+
+		let totaGasUsed = BigNumber.from(0)
+		for (let i=0; i<iterations; i++) {
+			await usdc.connect(addr1).approve(pool.address, deposit)
+			const tx = await pool.connect(addr1).deposit(deposit)
+			const gasUsed = (await tx.wait()).gasUsed;
+			console.log(i, "deposit: ", fromUsdc(deposit)), ", balance: ", fromUsdc( await usdc.balanceOf(addr1.address) )
+			totaGasUsed = totaGasUsed.add(gasUsed)
+			console.log(i, "gasUsed: ", gasUsed.toString(), totaGasUsed.toString())
+
+			await waitSeconds( 10 * 60 )
+		}
+
+		const avgGasUsed = totaGasUsed.div(iterations).toNumber()
+		console.log("avgGasUsed: ", avgGasUsed)
+		
+		const [_, price] = await wbtcFeed.latestRoundData()
+		console.log("btc price: ", Math.round( price.toNumber() / 10 ** 8)  )
+
+		console.log("pool usdc balance: ", fromUsdc( await usdc.balanceOf(pool.address)))
+		console.log("pool btc balance: ", fromBtc( await wbtc.balanceOf(pool.address)))
+		console.log("pool value: ", fromUsdc( await pool.totalValue()))
+		console.log("pool risk asset: ", fromUsdc( await pool.riskAssetValue()))
+		console.log("pool stable asset: ", fromUsdc( await pool.stableAssetValue()))
+	
+		expect( avgGasUsed ).to.lessThan( 530_000 )
+
+	}).timeout(60_000);
+
+});
+
+
+

--- a/test/gas_pool_exec_twap.ts
+++ b/test/gas_pool_exec_twap.ts
@@ -1,0 +1,176 @@
+
+
+
+import { Contract, BigNumber } from "ethers"
+import { ethers } from "hardhat";
+
+import { fromBtc, fromUsdc, waitSeconds, transferFunds } from "./helpers";
+
+import addresses from "../conf/addresses.json";
+import enums from "../conf/enums.json";
+
+import erc20_abi from "../scripts/abis/erc20.json";
+import pricefeed_aggregator_abi from "./abi/price_feed_aggreagator.json"
+import { expect } from "chai";
+
+const usdc_decimals = 6
+
+
+async function deployPoolContract() {
+
+	// 1. Deploy Pool LP token
+	const PoolLPToken = await ethers.getContractFactory("PoolLPToken")
+	const poolLPToken = await PoolLPToken.deploy("Pool LP Token", "PoolLP", 6)
+	await poolLPToken.deployed()
+
+	// 2. Depoly Strategy
+	const TrendFollowV1 = await ethers.getContractFactory("TrendFollowV1")
+
+	const strategy = await TrendFollowV1.deploy(
+		'0x0000000000000000000000000000000000000000',// pool address not known yet
+		addresses.polygon.usdc_usd_aggregator,
+		addresses.polygon.wbtc_usd_aggregator,
+		addresses.polygon.usdc, 
+		addresses.polygon.wbtc, 
+		40,      // moving average period (movingAveragePeriod)
+		19952 * (10 ** 8) ,  // initial 50D SMA value (initialMeanValue)
+	); 
+	await strategy.deployed()
+	await strategy.setUpkeepInterval(5 * 86400) // run every 5 days
+
+
+	// 3. Deploy Router
+	const SwapsRouter = await ethers.getContractFactory("SwapsRouter")
+	const swapRouter = await SwapsRouter.deploy(
+		addresses.polygon.uniswap_v3_quoter,
+		addresses.polygon.quickswap_v3_quoter
+	)
+	await swapRouter.deployed(); 
+
+	// 4. Deploy Pool
+	const poolFees = 100        // 1% fee
+	const uniswapV3Fee = 3000
+	const swapMaxValue = 10_000 * 10 ** 6  // 10k per swap
+
+	const PoolV4 = await ethers.getContractFactory("PoolV4")
+	const pool = await PoolV4.deploy(
+		swapRouter.address,
+		addresses.polygon.usdc_usd_aggregator,
+		addresses.polygon.wbtc_usd_aggregator,
+		addresses.polygon.usdc,
+		addresses.polygon.wbtc,
+		poolLPToken.address,
+		strategy.address,
+		poolFees,
+		uniswapV3Fee,
+		swapMaxValue
+	)
+	await pool.deployed()
+
+	// Configure LP token
+	await poolLPToken.addMinter(pool.address)
+
+	// Configure strategy
+	await strategy.setPool(pool.address)
+	await strategy.transferOwnership(pool.address)
+
+	// Configure Router
+	await swapRouter.addRouter( addresses.polygon.uniswap_v3_router, enums.RouterVersion.V3, enums.RouterType.Uniswap )
+	await swapRouter.addRouter( addresses.polygon.quickswap_v3_router, enums.RouterVersion.V3, enums.RouterType.QuickSwap )
+	await swapRouter.addRouter( addresses.polygon.quickswap_v2_router, enums.RouterVersion.V2, enums.RouterType.QuickSwap )
+	await swapRouter.setActiveRouter(0)
+
+	const usdc = new Contract(addresses.polygon.usdc, erc20_abi, ethers.provider)
+	const wbtc = new Contract(addresses.polygon.wbtc, erc20_abi, ethers.provider)
+
+	const wbtcFeed = new Contract(addresses.polygon.wbtc_usd_aggregator, pricefeed_aggregator_abi, ethers.provider)
+ 
+	return { poolLPToken, swapRouter, strategy, pool, usdc, wbtc, wbtcFeed };
+}
+
+
+
+describe("TWAP processing gas", function () {
+
+	it.only("Exec TWAP swaps until untill slippage is exceeded or full size is executed", async function () {
+
+		const { pool, usdc, wbtc, wbtcFeed } = await deployPoolContract()
+
+		const [ owner, addr1 ] = await ethers.getSigners();
+		await transferFunds(1_000_000 * 10 ** usdc_decimals, addr1.address)
+	
+		const balance = await usdc.balanceOf(addr1.address)
+		console.log("addr1 balance: ", fromUsdc(balance))
+
+		// $2m deposit 
+		await usdc.connect(addr1).approve(pool.address, balance)
+		const tx = await pool.connect(addr1).deposit(balance)
+		const gasUsed = (await tx.wait()).gasUsed;
+		console.log("deposit: ", fromUsdc(balance)), ", balance: ", fromUsdc( await usdc.balanceOf(addr1.address) )
+		console.log("deposit gasUsed: ", gasUsed.toString())
+
+		
+		let totaGasUsed = BigNumber.from(0)
+		let upkeepNedded5 = false
+		let swapped = 0
+		let i=0;
+		do {
+			[upkeepNedded5] = await pool.checkUpkeep(new Int8Array())
+			console.log("checkUpkeep: ", upkeepNedded5)
+
+			if (upkeepNedded5) {
+				i++
+
+				// exec strategy
+				const tx = await pool.performUpkeep(new Int8Array())
+				const gasUsed = (await tx.wait()).gasUsed;
+				const events = (await tx.wait()).events;
+				totaGasUsed = totaGasUsed.add(gasUsed)
+
+				const swapInfo = await pool.twapSwaps()
+				expect( swapInfo.side ).is.equal(enums.ActionType.BUY)
+				const swapEvents = events?.filter((x) => { return x.event === "Swapped" })
+				const swapError = events?.filter((x) => { return x.event === "SwapError" })
+
+				const error = swapError && swapError.length > 0 ? swapError?.[0] : ''
+				console.log("error: ",  error )
+
+				const swapEvent = swapEvents && swapEvents![swapEvents.length-1]
+				swapped = swapEvent?.args?.['spent']?.toNumber()
+
+			
+
+				console.log("-----", i, "iteration ---- gasUsed ", gasUsed.toString(), "swapped: ", swapped )
+				console.log( "swap size: ", fromUsdc( swapInfo.size ), "USDC" ,"- processed: ", Math.round (10000 * swapInfo.sold.toNumber() / swapInfo.total.toNumber()) / 100, "%" )
+
+				console.log("usdc balance: ", fromUsdc( await usdc.balanceOf(pool.address)))
+				console.log("btc balance: ", fromBtc( await wbtc.balanceOf(pool.address)))
+				console.log("pool value: ", fromUsdc( await pool.totalValue()))
+				console.log("risk assets: ", fromUsdc( await pool.riskAssetValue()))
+				console.log("stable assets: ", fromUsdc( await pool.stableAssetValue()))
+			}
+
+			await waitSeconds( 10 * 60 )
+
+		} while (upkeepNedded5 && swapped > 0) 
+
+		const swapInfo = await pool.twapSwaps()
+		console.log(">>> SWAP - sold: ", fromUsdc( swapInfo.sold ), "of", fromUsdc( swapInfo.total ), "==>",  Math.round (100 * swapInfo.sold.toNumber() / swapInfo.total.toNumber()), "%" )
+
+		const avgGasUsed = totaGasUsed.div(i).toNumber()
+		console.log(">>> avg gas per swap: ", avgGasUsed)
+		
+		console.log("pool usdc balance: ", fromUsdc( await usdc.balanceOf(pool.address)))
+		console.log("pool btc balance: ", fromBtc( await wbtc.balanceOf(pool.address)))
+		console.log("pool value: ", fromUsdc( await pool.totalValue()))
+		console.log("pool risk asset: ", fromUsdc( await pool.riskAssetValue()))
+		console.log("pool stable asset: ", fromUsdc( await pool.stableAssetValue()))
+	
+		expect( avgGasUsed ).to.lessThan( 350_000 )
+
+	}).timeout(60_000);
+
+});
+
+
+

--- a/test/gas_pool_exec_twap.ts
+++ b/test/gas_pool_exec_twap.ts
@@ -92,7 +92,7 @@ async function deployPoolContract() {
 
 describe("TWAP processing gas", function () {
 
-	it.only("Exec TWAP swaps until untill slippage is exceeded or full size is executed", async function () {
+	it.skip("Exec TWAP swaps until untill slippage is exceeded or full size is executed", async function () {
 
 		const { pool, usdc, wbtc, wbtcFeed } = await deployPoolContract()
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -84,7 +84,7 @@ export const fromUnits = (amount: BigNumber, decimals: Number, precision: Number
     const precisionFactor =  BigNumber.from('10').pow(BigNumber.from(precision)); 
     const number = BigNumber.from(amount).mul(precisionFactor).div(decimalsFactor)
 
-    const decimal = (number.toString().length > 17) ? 
+    const decimal = (number.toString().length > 15) ? 
         number.div(precisionFactor).toNumber()   :
         number.toNumber() / precisionFactor.toNumber()
 

--- a/test/pool_deposit_tests.ts
+++ b/test/pool_deposit_tests.ts
@@ -47,6 +47,7 @@ describe("PoolV4", function () {
         // 4. Deploy Pool
         const poolFees = 100        // 1% fee
         const uniswapV3Fee = 3000
+        const swapMaxValue = 10_000 * 10 ** 6
 
 		const PoolV4 = await ethers.getContractFactory("PoolV4")
 		const pool = await PoolV4.deploy(
@@ -58,7 +59,8 @@ describe("PoolV4", function () {
             poolLPToken.address,
             strategy.address,
             poolFees,
-            uniswapV3Fee
+            uniswapV3Fee,
+            swapMaxValue
         )
 		await pool.deployed()
 

--- a/test/pool_strategy_exec_tests.ts
+++ b/test/pool_strategy_exec_tests.ts
@@ -83,6 +83,7 @@ describe("PoolV4", function () {
         // 4. Deploy Pool
         const poolFees = 0        // 1% fee
         const uniswapV3Fee = 3000
+        const swapMaxValue = 10_000 * 10 ** 6
 
         const PoolV4 = await ethers.getContractFactory("PoolV4")
         const pool = await PoolV4.deploy(
@@ -94,7 +95,8 @@ describe("PoolV4", function () {
             poolLPToken.address,
             strategy.address,
             poolFees,
-            uniswapV3Fee
+            uniswapV3Fee,
+            swapMaxValue
         )
         await pool.deployed()
 

--- a/test/pool_withdraw_fee_tests.ts
+++ b/test/pool_withdraw_fee_tests.ts
@@ -85,6 +85,7 @@ describe("PoolV4", function () {
         // 4. Deploy Pool
         const poolFees = 100        // 1% fee
         const uniswapV3Fee = 3000
+        const swapMaxValue = 10_000 * 10 ** 6
 
 		const PoolV4 = await ethers.getContractFactory("PoolV4")
 		const pool = await PoolV4.deploy(
@@ -96,7 +97,8 @@ describe("PoolV4", function () {
             poolLPToken.address,
             strategy.address,
             poolFees,
-            uniswapV3Fee
+            uniswapV3Fee,
+            swapMaxValue
         )
 		await pool.deployed()
 

--- a/test/pool_withdraw_tests.ts
+++ b/test/pool_withdraw_tests.ts
@@ -88,6 +88,7 @@ describe("PoolV4", function () {
         // 4. Deploy Pool
         const poolFees = 0        // 1% fee
         const uniswapV3Fee = 3000
+        const swapMaxValue = 10_000 * 10 ** 6
 
 		const PoolV4 = await ethers.getContractFactory("PoolV4")
 		const pool = await PoolV4.deploy(
@@ -99,7 +100,8 @@ describe("PoolV4", function () {
             poolLPToken.address,
             strategy.address,
             poolFees,
-            uniswapV3Fee
+            uniswapV3Fee,
+            swapMaxValue
         )
 		await pool.deployed()
 


### PR DESCRIPTION
Problem:
When a strategy requires to execute a large swaps (e.g in the order of millions of USD in value) it could obtains  from the AMM an average price that is significantly worse than the oracle price. In the bast case this means the the pool receive proportionally less assets than it would for a smaller swap, in the worst case the swap would fail due to max slippage threshold getting hit.

Solution:
Process large swaps in chunks, as a sequence of smaller swaps, over a period of time, to allow liquidity in the AMM to reconstitute minimising price impact for the large swap.
This technique of order execution is usually referred as time weighed average price (TWAP).